### PR TITLE
Upgrade to Version 3.1 - Update Minecraft Version in Install Script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG V3.1
 - [x] Ability to update your instance to a newer Minecraft version from ```init_setup.sh```
-- [ ] Testing of feature
+- [x] Testing of feature
 - [x] General clean-up of files - reduces overall package size
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,6 @@
-# CHANGELOG V3.0 - Introducing Install Scripts
+# CHANGELOG V3.1
+- [ ] Ability to update your instance to a newer Minecraft version from ```init_setup.sh```
 
-- [x] Creation of install script
-    - [x] Allows the option of picking versions and it will set up the environment based on the version you choose
-- [x] Updated for 1.21.7
-- [x] Updated for 1.21.8 
-    - [x] Version support
-    - [x] Bluemaps migration
-- [x] Support more legacy versions of Minecraft
-- [x] Documentation update
 
 ## Future Plans
-- [ ] Ability to update your instance to a newer Minecraft version
 - [ ] Ability to add your Minecraft world to the setup and the environment will be set up around your worlds.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG V3.1
-- [ ] Ability to update your instance to a newer Minecraft version from ```init_setup.sh```
+- [x] Ability to update your instance to a newer Minecraft version from ```init_setup.sh```
+- [ ] Testing of feature
+- [x] General clean-up of files - reduces overall package size
 
 
 ## Future Plans

--- a/README.md
+++ b/README.md
@@ -24,11 +24,15 @@ This configuration allows players to connect through a single proxy and enjoy bo
 - **RCON:** Allows for easy server management using standard Minecraft commands outside the Minecraft client.
 
 ## Versions:
- V3.0 currently works for versions between 1.21.8 - 1.16.5 this may work with other versions of Minecraft assuming plugins and mods are changed accordingly. However, they have not been tested.  
+ V3.1 currently works for versions between 1.21.8 - 1.16.5 this may work with other versions of Minecraft assuming plugins and mods are changed accordingly. However, they have not been tested.  
  
  To change to a different version, you must:
- 1. Run the ```init_setup.sh``` script again and select your new version , this will download the mods and plugins for your selected version.
- 2. Remove the old Plugins and Mods located in the ```plugins/``` and ```mods/``` directories respectively to reflect the version you want to change to.
+
+Run the ```init_setup.sh``` script with the ```-u``` flag as shown below
+```
+$ init_setup.sh -u
+```
+This will let you enter your new Minecraft version and will change all jars & configurations for you :)
 
 
 

--- a/init_setup.sh
+++ b/init_setup.sh
@@ -5,121 +5,191 @@ MODS_DIR="./mods"
 PLUGINS_DIR="./plugins"
 DOCKER_COMPOSE_FILE="docker-compose.yml"
 
-read -p "Enter your Minecraft Version (e.g: 1.21.5): " MC_VERSION
+show_help() {
+    echo "Usage: ./init_setup.sh [OPTION]"
+    echo "Options:"
+    echo "  -s, --setup, -i, --install      Starts the initial setup"
+    echo "  -u, --update                    Updated the current server with a new Minecraft version"
+    echo "  -h, --help                      Show this help message"
+}
 
-if jq -e --arg v "$MC_VERSION" 'has($v)' "$JARS_FILE" > /dev/null; then
-    echo "Minecraft version $MC_VERSION is supported."
-else
-    echo "Error: Minecraft version $MC_VERSION is not supported."
-    exit 1
-fi
+version_select() {
+    read -p "Enter your Minecraft Version (e.g: 1.21.5): " MC_VERSION
 
-mkdir -p "$MODS_DIR" "$PLUGINS_DIR"
-
-echo "Downloading Mods and Plugins for version $MC_VERSION..."
-
-jq -r --arg v "$MC_VERSION" '.[$v] | to_entries[] | "\(.key)\t\(.value)"' "$JARS_FILE" \
-| while IFS=$'\t' read -r subkey url; do
-    if [[ $subkey == *paper ]]; then
-        dest="$PLUGINS_DIR"
+    if jq -e --arg v "$MC_VERSION" 'has($v)' "$JARS_FILE" > /dev/null; then
+        echo "$MC_VERSION"
     else
-        dest="$MODS_DIR"
-    fi
-
-    echo "$subkey: Downloading from $url to $dest"
-
-    if ! wget -N --show-progress -P "$dest" "$url"; then
-        echo "Error downloading $subkey from $url" >&2
+        echo "Error: Minecraft version $MC_VERSION is not supported." >&2
         exit 1
     fi
-done
+}
 
-echo "All mods and plugins downloaded successfully."
+jars_download() {
+    MC_VERSION=$1
 
-echo "Editing Docker Compose file..."
-if [[ -f "$DOCKER_COMPOSE_FILE" ]]; then
-    echo "Setting Minecraft version to $MC_VERSION in $DOCKER_COMPOSE_FILE"
-    sed -i -E "s/^( *VERSION:[[:space:]]*).*/\1$MC_VERSION/" "$DOCKER_COMPOSE_FILE"
+    mkdir -p "$MODS_DIR" "$PLUGINS_DIR"
 
-    read -p "Select your difficulty (peaceful, easy, normal, hard) [default: easy]: " DIFFICULTY
-    DIFFICULTY=${DIFFICULTY:-easy}
-    if [[ "$DIFFICULTY" =~ ^(peaceful|easy|normal|hard)$ ]]; then
-        echo "Setting difficulty to $DIFFICULTY in $DOCKER_COMPOSE_FILE"
-        sed -i -E "s/^( *DIFFICULTY:[[:space:]]*).*/\1$DIFFICULTY/" "$DOCKER_COMPOSE_FILE" 
+    echo "Downloading Mods and Plugins for version $MC_VERSION..."
+
+    jq -r --arg v "$MC_VERSION" '.[$v] | to_entries[] | "\(.key)\t\(.value)"' "$JARS_FILE" \
+    | while IFS=$'\t' read -r subkey url; do
+        if [[ $subkey == *paper ]]; then
+            dest="$PLUGINS_DIR"
+        else
+            dest="$MODS_DIR"
+        fi
+
+        echo "$subkey: Downloading from $url to $dest"
+
+        if ! wget -N --show-progress -P "$dest" "$url"; then
+            echo "Error downloading $subkey from $url" >&2
+            exit 1
+        fi
+    done
+
+    echo "All mods and plugins downloaded successfully."
+}
+
+edit_compose() {
+    MC_VERSION=$1
+
+    echo "Editing Docker Compose file..."
+    if [[ -f "$DOCKER_COMPOSE_FILE" ]]; then
+        echo "Setting Minecraft version to $MC_VERSION in $DOCKER_COMPOSE_FILE"
+        sed -i -E "s/^( *VERSION:[[:space:]]*).*/\1$MC_VERSION/" "$DOCKER_COMPOSE_FILE"
     else
-        echo "Invalid difficulty. Using default: easy"
-        sed -i -E "s/^( *DIFFICULTY:[[:space:]]*).*/\1easy/" "$DOCKER_COMPOSE_FILE"
+        echo "Error: $DOCKER_COMPOSE_FILE not found!"
+        exit 1
     fi
+}
 
-    read -p "Select your game mode (survival, creative, adventure, spectator) [default: survival]: " GAMEMODE
-    GAMEMODE=${GAMEMODE:-survival}
-    if [[ "$GAMEMODE" =~ ^(survival|creative|adventure|spectator)$ ]]; then
-        echo "Setting game mode to $GAMEMODE in $DOCKER_COMPOSE_FILE"
-        sed -i -E "s/^( *MODE:[[:space:]]*).*/\1$GAMEMODE/" "$DOCKER_COMPOSE_FILE"
-    else
-        echo "Invalid game mode. Using default: survival"
-        sed -i -E "s/^( *MODE:[[:space:]]*).*/\1survival/" "$DOCKER_COMPOSE_FILE"
-    fi  
+init_setup() {
+    MC_VERSION=$(version_select </dev/tty)
+    echo "Minecraft version $MC_VERSION is supported."
 
-    read -p "Enter your minecraft username for lvl 4 ops (leave blank for none): " MC_USERNAME
-    if [[ -n "$MC_USERNAME" ]]; then
-        echo "Setting OP username to $MC_USERNAME in $DOCKER_COMPOSE_FILE"
-        sed -i -E "s/^( *OPS:[[:space:]]*).*/\1\"$MC_USERNAME\"/" "$DOCKER_COMPOSE_FILE"
-    else
-        echo "No OP username provided. Leaving blank."
-        sed -i -E "s/^( *OPS:[[:space:]]*).*/\1\"\"/" "$DOCKER_COMPOSE_FILE"
-    fi
+    jars_download $MC_VERSION
 
-    read -p "Enable hardcore mode for FABRIC? (true/false) [default: false]: " HARDCORE_FABRIC
-    read -p "Enable hardcore mode for PAPER?  (true/false) [default: false]: " HARDCORE_PAPER
+    edit_compose $MC_VERSION
 
-    HARDCORE_FABRIC=${HARDCORE_FABRIC:-false}
-    HARDCORE_PAPER=${HARDCORE_PAPER:-false}
+    if [[ -f "$DOCKER_COMPOSE_FILE" ]]; then
+        read -p "Select your difficulty (peaceful, easy, normal, hard) [default: easy]: " DIFFICULTY
+        DIFFICULTY=${DIFFICULTY:-easy}
+        if [[ "$DIFFICULTY" =~ ^(peaceful|easy|normal|hard)$ ]]; then
+            echo "Setting difficulty to $DIFFICULTY in $DOCKER_COMPOSE_FILE"
+            sed -i -E "s/^( *DIFFICULTY:[[:space:]]*).*/\1$DIFFICULTY/" "$DOCKER_COMPOSE_FILE" 
+        else
+            echo "Invalid difficulty. Using default: easy"
+            sed -i -E "s/^( *DIFFICULTY:[[:space:]]*).*/\1easy/" "$DOCKER_COMPOSE_FILE"
+        fi
 
-    valid_bool() { [[ "$1" =~ ^(true|false)$ ]]; }
-    valid_bool "$HARDCORE_FABRIC" || HARDCORE_FABRIC=false
-    valid_bool "$HARDCORE_PAPER"  || HARDCORE_PAPER=false
+        read -p "Select your game mode (survival, creative, adventure, spectator) [default: survival]: " GAMEMODE
+        GAMEMODE=${GAMEMODE:-survival}
+        if [[ "$GAMEMODE" =~ ^(survival|creative|adventure|spectator)$ ]]; then
+            echo "Setting game mode to $GAMEMODE in $DOCKER_COMPOSE_FILE"
+            sed -i -E "s/^( *MODE:[[:space:]]*).*/\1$GAMEMODE/" "$DOCKER_COMPOSE_FILE"
+        else
+            echo "Invalid game mode. Using default: survival"
+            sed -i -E "s/^( *MODE:[[:space:]]*).*/\1survival/" "$DOCKER_COMPOSE_FILE"
+        fi  
 
-    if ! command -v yq >/dev/null 2>&1; then
-        echo "ERROR: 'yq' is required but not installed. Please install 'yq' to proceed. Setting HARDCORE to false by default."
-        sed -i -E "s/(HARDCORE:[[:space:]]*).*/\1false/" "$DOCKER_COMPOSE_FILE"
-    else
-        echo "Updating HARDCORE for FABRIC/PAPER in $DOCKER_COMPOSE_FILE ..."
-        YQ_EXPR="
-            .services.MCFABRIC.environment.HARDCORE = ${HARDCORE_FABRIC} |
-            .services.MCPAPER .environment.HARDCORE  = ${HARDCORE_PAPER}
-        "
+        read -p "Enter your minecraft username for lvl 4 ops (leave blank for none): " MC_USERNAME
+        if [[ -n "$MC_USERNAME" ]]; then
+            echo "Setting OP username to $MC_USERNAME in $DOCKER_COMPOSE_FILE"
+            sed -i -E "s/^( *OPS:[[:space:]]*).*/\1\"$MC_USERNAME\"/" "$DOCKER_COMPOSE_FILE"
+        else
+            echo "No OP username provided. Leaving blank."
+            sed -i -E "s/^( *OPS:[[:space:]]*).*/\1\"\"/" "$DOCKER_COMPOSE_FILE"
+        fi
 
-        if ! yq -i -y "$YQ_EXPR" "$DOCKER_COMPOSE_FILE" 2>/dev/null; then
-            echo "yq -i -y failed, using temp-file fallback (compatible with other yq versions)..."
-            tmpfile="$(mktemp)"
-            if yq -y "$YQ_EXPR" "$DOCKER_COMPOSE_FILE" > "$tmpfile"; then
-                mv "$tmpfile" "$DOCKER_COMPOSE_FILE"
-            else
-                echo "ERROR: yq failed to process $DOCKER_COMPOSE_FILE" >&2
-                rm -f "$tmpfile"
+        read -p "Enable hardcore mode for FABRIC? (true/false) [default: false]: " HARDCORE_FABRIC
+        read -p "Enable hardcore mode for PAPER?  (true/false) [default: false]: " HARDCORE_PAPER
+
+        HARDCORE_FABRIC=${HARDCORE_FABRIC:-false}
+        HARDCORE_PAPER=${HARDCORE_PAPER:-false}
+
+        valid_bool() { [[ "$1" =~ ^(true|false)$ ]]; }
+        valid_bool "$HARDCORE_FABRIC" || HARDCORE_FABRIC=false
+        valid_bool "$HARDCORE_PAPER"  || HARDCORE_PAPER=false
+
+        if ! command -v yq >/dev/null 2>&1; then
+            echo "ERROR: 'yq' is required but not installed. Please install 'yq' to proceed. Setting HARDCORE to false by default."
+            sed -i -E "s/(HARDCORE:[[:space:]]*).*/\1false/" "$DOCKER_COMPOSE_FILE"
+        else
+            echo "Updating HARDCORE for FABRIC/PAPER in $DOCKER_COMPOSE_FILE ..."
+            YQ_EXPR="
+                .services.MCFABRIC.environment.HARDCORE = ${HARDCORE_FABRIC} |
+                .services.MCPAPER .environment.HARDCORE  = ${HARDCORE_PAPER}
+            "
+
+            if ! yq -i -y "$YQ_EXPR" "$DOCKER_COMPOSE_FILE" 2>/dev/null; then
+                echo "yq -i -y failed, using temp-file fallback (compatible with other yq versions)..."
+                tmpfile="$(mktemp)"
+                if yq -y "$YQ_EXPR" "$DOCKER_COMPOSE_FILE" > "$tmpfile"; then
+                    mv "$tmpfile" "$DOCKER_COMPOSE_FILE"
+                else
+                    echo "ERROR: yq failed to process $DOCKER_COMPOSE_FILE" >&2
+                    rm -f "$tmpfile"
+                fi
             fi
         fi
-    fi
 
-    read -p "Enter backup interval in minutes (default 60): " BACKUP_INTERVAL
-    BACKUP_INTERVAL=${BACKUP_INTERVAL:-60}
-    if [[ "$BACKUP_INTERVAL" =~ ^[0-9]+$ ]]; then
-        echo "Setting backup interval to $BACKUP_INTERVAL minutes in $DOCKER_COMPOSE_FILE"
-        sed -i -E "s/(BACKUP_INTERVAL:[[:space:]]*).*/\1$BACKUP_INTERVAL/" "$DOCKER_COMPOSE_FILE"
+        read -p "Enter backup interval in minutes (default 60): " BACKUP_INTERVAL
+        BACKUP_INTERVAL=${BACKUP_INTERVAL:-60}
+        if [[ "$BACKUP_INTERVAL" =~ ^[0-9]+$ ]]; then
+            echo "Setting backup interval to $BACKUP_INTERVAL minutes in $DOCKER_COMPOSE_FILE"
+            sed -i -E "s/(BACKUP_INTERVAL:[[:space:]]*).*/\1$BACKUP_INTERVAL/" "$DOCKER_COMPOSE_FILE"
+        else
+            echo "Invalid input. Using default: 60 minutes"
+            sed -i -E "s/(BACKUP_INTERVAL:[[:space:]]*).*/\160/" "$DOCKER_COMPOSE_FILE"
+        fi
+
+        echo "Docker Compose file updated successfully."
     else
-        echo "Invalid input. Using default: 60 minutes"
-        sed -i -E "s/(BACKUP_INTERVAL:[[:space:]]*).*/\160/" "$DOCKER_COMPOSE_FILE"
+        echo "Error: $DOCKER_COMPOSE_FILE not found!"
+        exit 1
     fi
 
-    echo "Docker Compose file updated successfully."
-else
-    echo "Error: $DOCKER_COMPOSE_FILE not found!"
-    exit 1
-fi
+    echo "Setting permissions for servers..."
+    sudo chown -R 1080:1080 ./MCFABRIC-data ./MCPAPER-data ./plugins ./mods ./MCPF-backups ./MCPROXY-data ./BlueMaps ./world-list.txt
 
-echo "Setting permissions for servers..."
-sudo chown -R 1080:1080 ./MCFABRIC-data ./MCPAPER-data ./plugins ./mods ./MCPF-backups ./MCPROXY-data ./BlueMaps ./world-list.txt
+    echo "Setup completed successfully. Starting servers..."
+    docker compose up -d
+}
 
-echo "Setup completed successfully. Starting servers..."
-docker compose up -d
+update_version() {
+    MC_VERSION=$(version_select </dev/tty)
+    echo "Minecraft version $MC_VERSION is supported."
+
+    echo "Removing old jar files"
+    rm mods/BlueMap-*.jar mods/fabric-api-*.jar mods/FabricProxy-Lite-*.jar
+    rm plugins/BlueMap-*.jar
+    
+    jars_download $MC_VERSION
+
+    edit_compose $MC_VERSION
+
+    echo "Update completed successfully. Starting servers..."
+    docker compose up -d
+}
+
+case "$1" in
+    -s|--setup|-i|--install)
+        echo "Inital setup started..."
+        init_setup
+        exit 0
+        ;;
+    -u|--update|--update-version)
+        echo "Updating instance started..."
+        update_version
+        exit 0
+        ;;
+    -h|--help|"")
+        show_help
+        exit 0
+        ;;
+    *)
+        echo "Invalid option: $1"
+        show_help
+        exit 1
+        ;;
+esac

--- a/init_setup.sh
+++ b/init_setup.sh
@@ -18,9 +18,10 @@ version_select() {
 
     if jq -e --arg v "$MC_VERSION" 'has($v)' "$JARS_FILE" > /dev/null; then
         echo "$MC_VERSION"
+        return 0
     else
-        echo "Error: Minecraft version $MC_VERSION is not supported." >&2
-        exit 1
+        echo "$MC_VERSION"
+        return 1
     fi
 }
 
@@ -58,14 +59,19 @@ edit_compose() {
         echo "Setting Minecraft version to $MC_VERSION in $DOCKER_COMPOSE_FILE"
         sed -i -E "s/^( *VERSION:[[:space:]]*).*/\1$MC_VERSION/" "$DOCKER_COMPOSE_FILE"
     else
-        echo "Error: $DOCKER_COMPOSE_FILE not found!"
+        echo "Error"
         exit 1
     fi
 }
 
 init_setup() {
     MC_VERSION=$(version_select </dev/tty)
-    echo "Minecraft version $MC_VERSION is supported."
+    if [[ $? -eq 0 ]]; then
+        echo "Minecraft version $MC_VERSION is supported."
+    else
+        echo "Error: Minecraft version $MC_VERSION is not supported."
+        exit 1
+    fi
 
     jars_download $MC_VERSION
 
@@ -158,15 +164,23 @@ init_setup() {
 
 update_version() {
     MC_VERSION=$(version_select </dev/tty)
-    echo "Minecraft version $MC_VERSION is supported."
+    if [[ $? -eq 0 ]]; then
+        echo "Minecraft version $MC_VERSION is supported."
+    else
+        echo "Error: Minecraft version $MC_VERSION is not supported."
+        exit 1
+    fi
 
     echo "Removing old jar files"
-    rm mods/BlueMap-*.jar mods/fabric-api-*.jar mods/FabricProxy-Lite-*.jar
-    rm plugins/BlueMap-*.jar
+    rm mods/bluemap-*.jar mods/BlueMap-*.jar mods/fabric-api-*.jar mods/FabricProxy-Lite-*.jar
+    rm plugins/BlueMap-*.jar mods/bluemap-*.jar
     
     jars_download $MC_VERSION
 
     edit_compose $MC_VERSION
+
+    echo "Setting permissions for servers..."
+    sudo chown -R 1080:1080 ./MCFABRIC-data ./MCPAPER-data ./plugins ./mods ./MCPF-backups ./MCPROXY-data ./BlueMaps ./world-list.txt
 
     echo "Update completed successfully. Starting servers..."
     docker compose up -d


### PR DESCRIPTION
# CHANGELOG V3.1
- [x] Ability to update your instance to a newer Minecraft version from ```init_setup.sh```
- [x] Testing of feature
- [x] General clean-up of files - reduces overall package size


## Future Plans
- [ ] Ability to add your Minecraft world to the setup and the environment will be set up around your worlds.